### PR TITLE
fix: scope GCP packages to prevent dependency confusion (BRISKET-W103)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Dependency confusion mitigation (BRISKET-W103):
+# @idc scoped packages are private IDC dependencies installed only from explicit
+# Git commit URLs in package.json — never from unscoped public registry names.
+# Pin all @idc/* git dependencies to full commit hashes, not branch names.

--- a/.webpack/rules/transpileJavaScript.js
+++ b/.webpack/rules/transpileJavaScript.js
@@ -17,13 +17,13 @@ function transpileJavaScript(mode) {
           // https://github.com/openlayers/openlayers#supported-browsers
           // 'ol', --> Should be fine
           // Add GCP extensions that need TypeScript transpilation
-          'ohif-gcp-extension',
-          'ohif-gcp-mode',
+          '@idc/gcp-extension',
+          '@idc/gcp-mode',
         ])
       : excludeNodeModulesExcept([
           // Add GCP extensions that need TypeScript transpilation
-          'ohif-gcp-extension',
-          'ohif-gcp-mode',
+          '@idc/gcp-extension',
+          '@idc/gcp-mode',
         ]);
 
   return {

--- a/idc-assets/app-config-template.js
+++ b/idc-assets/app-config-template.js
@@ -7,7 +7,7 @@ window.config = {
     '@ohif/mode-segmentation': {
       hide: true,
     },
-    'ohif-gcp-mode': {
+    '@idc/gcp-mode': {
       hide: true,
     }
   },

--- a/platform/app/package.json
+++ b/platform/app/package.json
@@ -49,8 +49,8 @@
   ],
   "dependencies": {
     "@ohif/extension-idc": "0.0.1",
-    "@idc/gcp-extension": "https://github.com/ImagingDataCommons/ohif-gcp-extension#87bf0b3e12b8bceef4e747c4f710eddb3fd94b01",
-    "@idc/gcp-mode": "https://github.com/ImagingDataCommons/ohif-gcp-mode#28b90ac0b2ed64c51ae26622035ed42e9901702e",
+    "@idc/gcp-extension": "https://github.com/ImagingDataCommons/ohif-gcp-extension#d006293822c5d1a8c831ac7606373e9c0d4807a1",
+    "@idc/gcp-mode": "https://github.com/ImagingDataCommons/ohif-gcp-mode#b1aab90176abde2adc5ab9e35d21289936317e0d",
     "@babel/runtime": "7.28.2",
     "@cornerstonejs/codec-charls": "1.2.3",
     "@cornerstonejs/codec-libjpeg-turbo-8bit": "1.2.2",

--- a/platform/app/package.json
+++ b/platform/app/package.json
@@ -49,8 +49,8 @@
   ],
   "dependencies": {
     "@ohif/extension-idc": "0.0.1",
-    "ohif-gcp-extension": "https://github.com/ImagingDataCommons/ohif-gcp-extension#main",
-    "ohif-gcp-mode": "https://github.com/ImagingDataCommons/ohif-gcp-mode#main",
+    "@idc/gcp-extension": "https://github.com/ImagingDataCommons/ohif-gcp-extension#87bf0b3e12b8bceef4e747c4f710eddb3fd94b01",
+    "@idc/gcp-mode": "https://github.com/ImagingDataCommons/ohif-gcp-mode#28b90ac0b2ed64c51ae26622035ed42e9901702e",
     "@babel/runtime": "7.28.2",
     "@cornerstonejs/codec-charls": "1.2.3",
     "@cornerstonejs/codec-libjpeg-turbo-8bit": "1.2.2",

--- a/platform/app/pluginConfig.json
+++ b/platform/app/pluginConfig.json
@@ -70,7 +70,7 @@
       "packageName": "@ohif/extension-idc"
     },
     {
-      "packageName": "ohif-gcp-extension",
+      "packageName": "@idc/gcp-extension",
       "version": "0.0.1"
     }
   ],
@@ -108,7 +108,7 @@
       "version": "3.0.0"
     },
     {
-      "packageName": "ohif-gcp-mode",
+      "packageName": "@idc/gcp-mode",
       "version": "0.0.1"
     }
   ],

--- a/platform/app/public/config/default.js
+++ b/platform/app/public/config/default.js
@@ -404,7 +404,7 @@ window.config = {
     '@ohif/mode-segmentation': {
       hide: true,
     },
-    'ohif-gcp-mode': {
+    '@idc/gcp-mode': {
       hide: true,
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2445,6 +2445,18 @@
   resolved "https://registry.yarnpkg.com/@icr/polyseg-wasm/-/polyseg-wasm-0.4.0.tgz#755e23d07c3d8d8fca1113278c803c1ef0185da0"
   integrity sha512-3sZmiwG8I0NaqPle0L7+V/ZexiR7IjIUFkUsaOoFI9rNuBGyyMMmxAxnCmqcDFtBDk9h+JEYJf6e3NnqlHi/HQ==
 
+"@idc/gcp-extension@https://github.com/ImagingDataCommons/ohif-gcp-extension#87bf0b3e12b8bceef4e747c4f710eddb3fd94b01":
+  version "0.0.1"
+  resolved "https://github.com/ImagingDataCommons/ohif-gcp-extension#87bf0b3e12b8bceef4e747c4f710eddb3fd94b01"
+  dependencies:
+    "@babel/runtime" "^7.20.13"
+
+"@idc/gcp-mode@https://github.com/ImagingDataCommons/ohif-gcp-mode#28b90ac0b2ed64c51ae26622035ed42e9901702e":
+  version "0.0.1"
+  resolved "https://github.com/ImagingDataCommons/ohif-gcp-mode#28b90ac0b2ed64c51ae26622035ed42e9901702e"
+  dependencies:
+    "@babel/runtime" "^7.20.13"
+
 "@inquirer/ansi@^1.0.0", "@inquirer/ansi@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@inquirer/ansi/-/ansi-1.0.2.tgz#674a4c4d81ad460695cb2a1fc69d78cd187f337e"
@@ -14953,18 +14965,6 @@ obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
-
-"ohif-gcp-extension@https://github.com/ImagingDataCommons/ohif-gcp-extension#main":
-  version "0.0.1"
-  resolved "https://github.com/ImagingDataCommons/ohif-gcp-extension#5b0f1abd847d531792e340f302e3e9f6eed685ec"
-  dependencies:
-    "@babel/runtime" "^7.20.13"
-
-"ohif-gcp-mode@https://github.com/ImagingDataCommons/ohif-gcp-mode#main":
-  version "0.0.1"
-  resolved "https://github.com/ImagingDataCommons/ohif-gcp-mode#38ebce6eea27a939442c0847257c0197f5ffd592"
-  dependencies:
-    "@babel/runtime" "^7.20.13"
 
 oidc-client-ts@3.3.0:
   version "3.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2445,15 +2445,15 @@
   resolved "https://registry.yarnpkg.com/@icr/polyseg-wasm/-/polyseg-wasm-0.4.0.tgz#755e23d07c3d8d8fca1113278c803c1ef0185da0"
   integrity sha512-3sZmiwG8I0NaqPle0L7+V/ZexiR7IjIUFkUsaOoFI9rNuBGyyMMmxAxnCmqcDFtBDk9h+JEYJf6e3NnqlHi/HQ==
 
-"@idc/gcp-extension@https://github.com/ImagingDataCommons/ohif-gcp-extension#87bf0b3e12b8bceef4e747c4f710eddb3fd94b01":
+"@idc/gcp-extension@https://github.com/ImagingDataCommons/ohif-gcp-extension#d006293822c5d1a8c831ac7606373e9c0d4807a1":
   version "0.0.1"
-  resolved "https://github.com/ImagingDataCommons/ohif-gcp-extension#87bf0b3e12b8bceef4e747c4f710eddb3fd94b01"
+  resolved "https://github.com/ImagingDataCommons/ohif-gcp-extension#d006293822c5d1a8c831ac7606373e9c0d4807a1"
   dependencies:
     "@babel/runtime" "^7.20.13"
 
-"@idc/gcp-mode@https://github.com/ImagingDataCommons/ohif-gcp-mode#28b90ac0b2ed64c51ae26622035ed42e9901702e":
+"@idc/gcp-mode@https://github.com/ImagingDataCommons/ohif-gcp-mode#b1aab90176abde2adc5ab9e35d21289936317e0d":
   version "0.0.1"
-  resolved "https://github.com/ImagingDataCommons/ohif-gcp-mode#28b90ac0b2ed64c51ae26622035ed42e9901702e"
+  resolved "https://github.com/ImagingDataCommons/ohif-gcp-mode#b1aab90176abde2adc5ab9e35d21289936317e0d"
   dependencies:
     "@babel/runtime" "^7.20.13"
 


### PR DESCRIPTION
## Summary
- Renames `ohif-gcp-mode` and `ohif-gcp-extension` to scoped `@idc/gcp-mode` and `@idc/gcp-extension` to prevent public npm registry substitution (Synack BRISKET-W103).
- Pins both dependencies to explicit Git commit SHAs instead of `#main`.
- Adds `.npmrc` documenting that `@idc` packages must be installed from Git URLs only.
- Updates plugin config, webpack transpilation rules, and app config references.

## Related changes
Requires the following commits on the GCP package repos (already on `main`):
- [ohif-gcp-mode@28b90ac](https://github.com/ImagingDataCommons/ohif-gcp-mode/commit/28b90ac0b2ed64c51ae26622035ed42e9901702e)
- [ohif-gcp-extension@87bf0b3](https://github.com/ImagingDataCommons/ohif-gcp-extension/commit/87bf0b3e12b8bceef4e747c4f710eddb3fd94b01)

## Test plan
- [ ] `yarn install --frozen-lockfile` succeeds
- [ ] `yarn build` completes without module resolution errors
- [ ] Deployed viewer loads GCP mode/extension correctly
- [ ] Confirm Synack finding BRISKET-W103 can be closed after redeploy