### PR TITLE
feat: unhide ultrasound pleura b-line mode

### DIFF
--- a/idc-assets/app-config-template.js
+++ b/idc-assets/app-config-template.js
@@ -1,9 +1,6 @@
 window.config = {
   routerBasename: '/v3',
   modesConfiguration: {
-    '@ohif/mode-ultrasound-pleura-bline': {
-      hide: true,
-    },
     '@ohif/mode-segmentation': {
       hide: true,
     },

--- a/platform/app/public/config/default.js
+++ b/platform/app/public/config/default.js
@@ -398,9 +398,6 @@ window.config = {
     },
   ],
   modesConfiguration: {
-    '@ohif/mode-ultrasound-pleura-bline': {
-      hide: true,
-    },
     '@ohif/mode-segmentation': {
       hide: true,
     },


### PR DESCRIPTION
## Summary
- Remove the `hide: true` configuration for `@ohif/mode-ultrasound-pleura-bline` so the mode is visible to users.
- Applied to both `platform/app/public/config/default.js` and `idc-assets/app-config-template.js`.

## Notes
- While applying the change, fixed an accidental deletion of the `modesConfiguration: {` opening line in `idc-assets/app-config-template.js` that would have produced invalid config JS. Both files now pass `node -c` syntax checks.

## Test plan
- [ ] Verify the ultrasound pleura b-line mode appears in the mode list in the viewer.
- [ ] Confirm config loads without errors in deployed environments using the template.